### PR TITLE
Create install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,14 @@
+pip install svgpathtools
+sudo apt-get update
+apt install -y imagemagick
+apt-get install libtool
+sudo apt install intltool imagemagick libmagickcore-dev pstoedit libpstoedit-dev autopoint
+
+git clone https://github.com/autotrace/autotrace.git
+cd ./autotrace
+./autogen.sh
+LD_LIBRARY_PATH=/usr/local/lib ./configure --prefix=/usr
+make
+sudo make install
+
+autotrace -v


### PR DESCRIPTION
I issued there are no command `convert`and `autotrace`. Although the problem of `convert` is easily solved by installing ìmagemagick`, `autotrace` is should be installed carefully.

My coworker "HyungBum Kim" provided this shell script.  In the environment (Ubuntu 20.04 LTS, anaconda python=3.9) in which I executed this shell script, it works perfectly